### PR TITLE
Remove reference to Symfony\Component\Translation\Tests\String, which…

### DIFF
--- a/src/OCLC/Auth/RefreshToken.php
+++ b/src/OCLC/Auth/RefreshToken.php
@@ -24,7 +24,6 @@ use Guzzle\Http\Client;
 use Guzzle\Plugin\History\HistoryPlugin;
 use OCLC\Auth\WSKey;
 use OCLC\User;
-use Symfony\Component\Translation\Tests\String;
 /**
  * A class that represents a client's OCLC Refresh Token.
  *


### PR DESCRIPTION
… uses a reserved word in PHP 7.

As of PHP 7, 'string' can no longer "be used to name a class, interface or trait, and [it is] also prohibited from being used in namespaces." (http://php.net/manual/en/reserved.other-reserved-words.php)

As far as I can tell, `Symfony\Component\Translation\Tests\String` isn't being used by `RefreshToken` anyway, so I removed the line referencing it.

Thanks,
Andrew
